### PR TITLE
Dockerfile updates

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,7 +1,10 @@
 FROM resin/%%RESIN_MACHINE_NAME%%-alpine-node:slim
 
+# Move to /usr/src/app
+WORKDIR /usr/src/app
+
 # Install packages.
-RUN apk add --update \
+RUN apk add --no-cache \
         --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
         build-base \
         git \
@@ -12,30 +15,26 @@ RUN apk add --update \
         py-smbus \
         py-psutil \
         eudev-dev \
-        && pip install --upgrade pip \
-        && rm -rf /var/cache/apk/*
+        && pip install --upgrade pip
 
 RUN pip install spidev RPi.GPIO python-uinput
 
-RUN git clone https://github.com/pimoroni/dot3k.git && cd dot3k/library && python ./setup.py install
-
-# Save source folder
-RUN printf "%s\n" "${PWD##}" > SOURCEFOLDER
-
-# Move to /usr/src/app
-WORKDIR /usr/src/app
+RUN git clone --depth=1 https://github.com/pimoroni/dot3k.git && \
+    cd dot3k/library && \
+    python ./setup.py install && \
+    cd ../../ && rm -rf dot3k
 
 # Move package to filesystem
-COPY "$SOURCEFOLDER/app/package.json" ./
+COPY ./app/package.json ./
 
 # Install NodeJS dependencies via NPM
 RUN JOBS=MAX npm i --unsafe-perm --production && npm cache clean
 
-# Start app
-CMD ["bash", "/usr/src/app/start.sh"]
-
 # Move app to filesystem
-COPY "$SOURCEFOLDER/app" ./
+COPY /app ./
 
 ## uncomment if you want systemd
 ENV INITSYSTEM on
+
+# Start app
+CMD ["bash", "/usr/src/app/start.sh"]


### PR DESCRIPTION
Some optional tuning of the Dockerfile. Feel free to pick and choose which is for your liking, or even ignore this PR. Build tested but not deploy tested yet!
- `apk` can instal with no local caching or indexing with `--no-cache`,
  so don't need to remember what directory to delete
- `WORKDIR` can be reused, and source folder is not required, always
  working from there on the input side (if I understand correctly)
- git clone only latest revision to save time, and delete directory
  afterwards (ideally this could be changed to using a specific commit
  for dot3k, that we know works, but it's not a big deal as our base
  image is not versioned at the moment either (but using latest))
- put `CMD` to the last row, for better understanding
